### PR TITLE
Fix config path for dashboard execution

### DIFF
--- a/core/script_generator.py
+++ b/core/script_generator.py
@@ -1,8 +1,7 @@
 import openai
-import json
+from utils.config import load_config
 
-with open("config.json", "r") as f:
-    config = json.load(f)
+config = load_config()
 
 client = openai.OpenAI(api_key=config["openai_api_key"])
 

--- a/core/video_creator.py
+++ b/core/video_creator.py
@@ -1,4 +1,3 @@
-import json
 import moviepy
 import requests
 import textwrap
@@ -6,10 +5,10 @@ from pathlib import Path
 from uuid import uuid4
 from PIL import Image, ImageDraw, ImageFont
 from moviepy import ImageClip, concatenate_videoclips, CompositeVideoClip, AudioFileClip
+from utils.config import load_config
 
 # Load OpenAI key
-with open("config.json", "r") as f:
-    config = json.load(f)
+config = load_config()
 
 OUTPUT_DIR = Path("core/outputs/videos")
 FRAME_DIR = Path("core/outputs/frames")

--- a/core/voiceover.py
+++ b/core/voiceover.py
@@ -1,11 +1,10 @@
 import requests
-import json
 import os
 from pathlib import Path
 from uuid import uuid4
+from utils.config import load_config
 
-with open("config.json", "r") as f:
-    config = json.load(f)
+config = load_config()
 
 ELEVENLABS_API_KEY = config["elevenlabs_api_key"]
 VOICE_ID = config["voice_id"]

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import json
+from utils.config import load_config
 from core.script_generator import generate_script
 from core.voiceover import synthesize_voice
 from core.video_creator import create_video
@@ -8,8 +8,7 @@ from core.topic_memory import save_topic
 from core.export import export_video
 from core.a_b_tester import create_multiple_variants
 
-with open("config.json", "r") as f:
-    config = json.load(f)
+config = load_config()
 
 def main():
     print("📽️  [YT Automation] Starting pipeline...")

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import json
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.json"
+
+def load_config():
+    with open(CONFIG_PATH, "r") as f:
+        return json.load(f)


### PR DESCRIPTION
## Summary
- load `config.json` using an absolute path helper
- update all modules to use the helper
- add `utils/config.py` for shared config loading

## Testing
- `python -m py_compile main.py core/*.py dashboard/app.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6845e915f6988333b371db90ec6cbd37